### PR TITLE
Provide better defaults for Prima::HelpViewer

### DIFF
--- a/Prima/HelpViewer.pm
+++ b/Prima/HelpViewer.pm
@@ -189,7 +189,13 @@ use vars qw(@ISA $finddlg $prndlg $setupdlg $inifile
 $defaultVariableFont $defaultFixedFont);
 @ISA = qw(Prima::Window);
 
-$inifile = Prima::IniFile-> create( Prima::Utils::path( 'HelpWindow'));
+$inifile = Prima::IniFile-> create(
+	file => Prima::Utils::path('HelpWindow'),
+	default => { View => {
+		FullText => 1,
+		FixedFont => 'monospace',
+	}},
+);
 
 sub profile_default
 {


### PR DESCRIPTION
Now the viewer displays the full pod documentation by default, and
for code it defaults to the 'monospace' font, which looks _much_
better on Mac and Linux.
