### PR TITLE
Minor changes for Mac OSX to compile without warnings and Fontconfig ...

### DIFF
--- a/img/codec_Xpm.c
+++ b/img/codec_Xpm.c
@@ -207,7 +207,7 @@ load( PImgCodec instance, PImgLoadFileInstance fi)
                   }
                   xc = ARGB( r, g, b);
                } else {
-                  xc = (Color) hash_fetch( c, s, strlen(s));
+                  xc = (Color) (uintptr_t)hash_fetch( c, s, strlen(s));
                   if ( xc) {
                      xc -= 10;
                   } else if ( stricmp( s, "none") == 0)  {
@@ -216,7 +216,7 @@ load( PImgCodec instance, PImgLoadFileInstance fi)
                      xc = 0;
                   } else {
                      xc = apc_lookup_color( s);
-                     hash_store( c, s, strlen(s), (void*)((Color)xc + 10));
+                     hash_store( c, s, strlen(s), (void*)((uintptr_t)(Color)xc + 10));
                      if ( xc == clInvalid) xc = 0;
                   }
                }

--- a/unix/xft.c
+++ b/unix/xft.c
@@ -93,7 +93,7 @@
 #define FC_WIDTH "width"
 #endif
 
-#if FC_MAJOR < 2 || ( FC_MAJOR == 2 && FC_MINOR < 10 )
+#if FC_MAJOR < 2 || ( FC_MAJOR == 2 && FC_MINOR > 10 )
 #define NEED_EXPLICIT_FC_SCALABLE 1
 #endif
 


### PR DESCRIPTION
- Compile warnings for size differences between a possible pointer which could be 64-bit to a 32-bit number.
- Fontconfig correction as suggested by Dmitry.
