### PR TITLE
- paint_widgets should not draw invisible children

### DIFF
--- a/Prima/Drawable/Subcanvas.pm
+++ b/Prima/Drawable/Subcanvas.pm
@@ -239,6 +239,7 @@ sub AUTOLOAD {
 sub paint_widgets
 {
 	my ( $self, $root, $x, $y ) = @_;
+	return unless $root->visible;
 
 	$self->offset($x,$y);
 	$self->{size} = [ $root->size ];


### PR DESCRIPTION
Updates `paint_widgets` to simply return (having done nothing) if the underlying widget is not visible.
