### PR TITLE
Fix build with ExtUtils::MakeMaker 7.00+ and Perl 5.21.6+.

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2079,8 +2079,8 @@ sub install
 	my $t = $self->SUPER::install(@_);
 	my $n = $t =~ s[
 		(pure_\w+_install.*?)                       # 1
-		(INST_ARCHLIB\)\s+)\$\(DEST(\w+)\)(.*?)     # 2,3,4
-		(INST_BIN\)\s+)\$\(DEST(\w+)\)(.*?)         # 5,6,7
+		(INST_ARCHLIB\)"?\s+"?)\$\(DEST(\w+)\)(.*?)     # 2,3,4
+		(INST_BIN\)"?\s+"?)\$\(DEST(\w+)\)(.*?)         # 5,6,7
 		(.*?)                                       # 8
 		\n\n
 	][


### PR DESCRIPTION
In 6.99_something, ExtUtils::MakeMaker began quoting all the make variables, so
regexps need to be updated to account for that.