### PR TITLE
Make Prima::Config relocatable

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1748,7 +1748,7 @@ use vars qw(%Config);
 use File::Basename qw(dirname);
 use File::Spec;
 my \$lib = File::Spec->catfile(dirname(__FILE__), '..');
-my \$bin = File::Spec->catfile(\$lib, qw( .. .. bin ));
+my \$bin = File::Spec->catfile(\$lib, qw( .. bin ));
 
 %Config = (
 HEADER

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1744,6 +1744,12 @@ sub command_postinstall
 package Prima::Config;
 use vars qw(%Config);
 
+# Determine lib and bin directories based on the location of this module
+use File::Basename qw(dirname);
+use File::Spec;
+my \$lib = File::Spec->catfile(dirname(__FILE__), '..');
+my \$bin = File::Spec->catfile(\$lib, qw( .. .. bin ));
+
 %Config = (
 HEADER
 	while ( <F>) {
@@ -1756,7 +1762,9 @@ HEADER
 				$ci_state = 0;
 			} elsif ( m/^\s*(\S+)\s*/ ) {
 				my $k = $1;
-				s/\$\((\w+)\)/$vars{$1}/g;
+				s/\$\((\w+)\)/\$$1/g;
+				s/'/"/g;
+				s{\\}{\\\\}g;
 				$ci{$k} = $_;
 			}
 		}


### PR DESCRIPTION
I've tested this in a limited way on Ubuntu, Mac, and Windows. This essentially incorporates kmx's hack, using `dirname(__FILE__)` to obtain the current module directory. I believe it addresses Ingo's issues from #29.