### PR TITLE
Revert "Make Prima::Config relocatable"

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1744,12 +1744,6 @@ sub command_postinstall
 package Prima::Config;
 use vars qw(%Config);
 
-# Determine lib and bin directories based on the location of this module
-use File::Basename qw(dirname);
-use File::Spec;
-my \$lib = File::Spec->catfile(dirname(__FILE__), '..');
-my \$bin = File::Spec->catfile(\$lib, qw( .. bin ));
-
 %Config = (
 HEADER
 	while ( <F>) {
@@ -1762,9 +1756,7 @@ HEADER
 				$ci_state = 0;
 			} elsif ( m/^\s*(\S+)\s*/ ) {
 				my $k = $1;
-				s/\$\((\w+)\)/\$$1/g;
-				s/'/"/g;
-				s{\\}{\\\\}g;
+				s/\$\((\w+)\)/$vars{$1}/g;
 				$ci{$k} = $_;
 			}
 		}


### PR DESCRIPTION
Reverts dk/Prima#30

Well I knew I've neen too hasty ... here's how it fails on linux:

dk@udayin src/IPA> perl -MPrima::Config -le 'print $Prima::Config::Config{gencls}'
/home/dk/perl5/perlbrew/perls/perl-5.14.2/lib/site_perl/5.14.2/i686-linux/Prima/../../bin/gencls
dk@udayin src/IPA> which gencls
/home/dk/perl5/perlbrew/perls/perl-5.14.2/bin/gencls
