### PR TITLE
Remove errant parenthesis

### DIFF
--- a/Prima/PS/Drawable.pm
+++ b/Prima/PS/Drawable.pm
@@ -1064,7 +1064,7 @@ sub bars
 	$c = int( $c / 4) * 4;
 	my $z = '';
 	for ( $i = 0; $i < $c; $i += 4) {
-		$z .= "N @a[$i,$i+1] M @a[$i,$i+3] l @a[$i+2,$i+3] l @a[$i+2,$i+1] l X F ");
+		$z .= "N @a[$i,$i+1] M @a[$i,$i+3] l @a[$i+2,$i+3] l @a[$i+2,$i+1] l X F ";
 	}
 	$self-> stroke( $z);
 }


### PR DESCRIPTION
An extra parenthesis (possibly left over from a copy-and-paste) led to compiler errors. This patch removes it.