### PR TITLE
Try Travis-CI configuration that install X11 dev files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ perl:
   - "5.16"
   - "5.14"
   - "5.12"
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq libX11-dev


### PR DESCRIPTION
I'm not sure why this fails on Travis-CI, but it might be because the X11 development files are not installed. This changes the configuration to install these files.