### PR TITLE
Fix t/Image/Bar.t under headless X11

### DIFF
--- a/t/Image/Bar.t
+++ b/t/Image/Bar.t
@@ -3,7 +3,6 @@ use warnings;
 
 use Test::More;
 use Prima::Test qw(noX11);
-use Prima::Application;
 
 plan tests => 1133;
 


### PR DESCRIPTION
This test was failing under headless X11 systems. Removing the
use of Prima::Application seems to fix the problem.