### PR TITLE
EUMM compatibility update

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2043,8 +2043,10 @@ sub command_cpbin
 sub c_o
 {
 	my $t = shift-> SUPER::c_o(@_);
-	unless ( $t =~ /.c\$\(OBJ_EXT\):\n\t.*\$\*\$\(OBJ_EXT\)/ ) {
-		$t =~ s/(\.c\$\(OBJ_EXT\):\n\t.*)/$1 $COUTOFLAG\$*\$(OBJ_EXT)/;
+	my $re1 = '\.c\$\(OBJ_EXT\):\n\t.*';
+	my $ending = '$*$(OBJ_EXT)';
+	unless ( $t =~ /$re1\Q$ending\E/ ) {
+		$t =~ s/($re1)/$1 $COUTOFLAG$ending/;
 	}
 	return $t;
 }

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2043,7 +2043,7 @@ sub command_cpbin
 sub c_o
 {
 	my $t = shift-> SUPER::c_o(@_);
-	my $re1 = '\.c\$\(OBJ_EXT\):\n\t.*';
+	my $re1 = '\.c\$\(OBJ_EXT\)\s*:\n\t.*';
 	my $ending = '$*$(OBJ_EXT)';
 	unless ( $t =~ /$re1\Q$ending\E/ ) {
 		$t =~ s/($re1)/$1 $COUTOFLAG$ending/;


### PR DESCRIPTION
Current `Makefile.PL` relies on the EUMM-generated `Makefile` having no spaces before `:` in rules. This patch removes that assumption, which is incorrect from EUMM 7.11_02. This addresses:

* this cpantesters failure: http://www.cpantesters.org/cpan/report/ce4cbb5e-917f-11e5-8342-5a9f251cf1b3
* this RT report: https://rt.cpan.org/Ticket/Display.html?id=109962
* this EUMM issue (which tracks blockers for EUMM 7.12): https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/issues/252