### PR TITLE
Indirect object syntax

### DIFF
--- a/Prima.pm
+++ b/Prima.pm
@@ -99,7 +99,7 @@ Prima - a perl graphic toolkit
 
 	use Prima qw(Application Buttons);
 
-	new Prima::MainWindow(
+	Prima::MainWindow->new(
 		text     => 'Hello world!',
 		size     => [ 200, 200],
 	)-> insert( Button =>
@@ -177,7 +177,7 @@ is finished.
 
 The window is created by invoking 
 
-	new Prima::MainWindow();
+	Prima::MainWindow->new();
 
 or
 
@@ -189,7 +189,7 @@ of parameters is passed afterwards. These parameters are usually
 represented in a hash syntax, although actually passed as an array.
 The hash syntax is preferred for the code readability:
 
-	$new_object = new Class(
+	$new_object = Class->new(
 		parameter => value,
 		parameter => value,
 		...

--- a/examples/calendar.pl
+++ b/examples/calendar.pl
@@ -18,7 +18,7 @@ use Prima::Application name => 'Calendar';
 use Prima::Calendar;
 
 my $cal;
-my $w = new Prima::MainWindow(
+my $w = Prima::MainWindow->new(
 	text => "Calendar example",
 	size => [ 200, 200],
 	designScale => [6,16],

--- a/examples/dwm_blur.pl
+++ b/examples/dwm_blur.pl
@@ -54,7 +54,7 @@ sub dwm_reset
 	}});
 }
 
-my $w = new Prima::MainWindow(
+my $w = Prima::MainWindow->new(
 	text => "Hello, world!",
 	backColor => cl::Black,
 	onSize => sub { dwm_reset(shift) },

--- a/examples/generic.pl
+++ b/examples/generic.pl
@@ -15,7 +15,7 @@ use warnings;
 use Prima;
 use Prima::Application name => 'Generic';
 
-my $w = new Prima::MainWindow(
+my $w = Prima::MainWindow->new(
 	text => "Hello, world!",
 	onClose => sub {
 		$::application-> destroy;


### PR DESCRIPTION
Hi,

I received your dist in this month's [CPAN PR Challenge](http://cpan-prc.org/).  When looking through the docs and examples, I noticed a few places where usage of indirect object syntax was still in use.

This minimal set of changes uses the ```Foo->new()``` syntax instead.

Thanks,
Chase