### PR TITLE
Correcting a literal error I think

### DIFF
--- a/Prima/FrameSet.pm
+++ b/Prima/FrameSet.pm
@@ -455,7 +455,7 @@ sub init
 					thickness => $profile{sliderWidth},
 					enabled => 1,
 					) : (
-					thickness => 1,
+					thickness => $profile{separatorWidth},
 					enabled => 0,
 					),
 # Horizontal arrangement of frames means we need a vertically oriented slider.


### PR DESCRIPTION
With this finally "separatorWidth" property makes sense. Without this, you can not change the width of the separataor, if you use the option "flexible => 0"!

I really think, it is just a misspelling..

Best wishes, Max