### PR TITLE
Makefile: Declare all files generated with utils/prima-gencls.pl

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2551,7 +2551,7 @@ SHOWMORE
 		my $ancestors = join(' ', map { "include/generic/$_.h class/$_.cls" } gencls( $clsfile, depend => 1, incpath => ['class']));
 	  	$t .= <<H;
 
-include/generic/$base.h: \$(FIRST_MAKEFILE) $showlog class/$base.cls $ancestors
+include/generic/$base.h include/generic/$base.inc include/generic/$base.tml: \$(FIRST_MAKEFILE) $showlog class/$base.cls $ancestors
 \t$^X -I. utils/prima-gencls.pl --inc --h -Iclass --tml $clsfile include/generic
 
 H


### PR DESCRIPTION
Parallel make randomly fails with:

/usr/bin/perl -I. utils/prima-gencls.pl --inc --h -Iclass --tml class/Object.cls include/generic /usr/bin/perl -I. utils/prima-gencls.pl --inc --h -Iclass --tml class/Utils.cls include/generic make: *** No rule to make target 'include/generic/Types.inc', needed by 'api/thunks.o'.  Stop. make: *** Waiting for unfinished jobs....
/usr/bin/perl -I. utils/prima-gencls.pl --inc --h -Iclass --tml class/Types.cls include/generic

Observe that api/thunks.c which includes include/generic/Types.inc is compiled before generating include/generic/Types.inc.

The cause is that Makefile does not declare that the inc files are generated by utils/prima-gencls.pl from cls files as can be verified with:

$ make -n api/thunks.o
/usr/bin/perl -I. utils/prima-gencls.pl --inc --h -Iclass --tml class/Types.cls include/generic [...]
make: *** No rule to make target 'include/generic/Types.inc', needed by 'api/thunks.o'.  Stop.

This patch adds all the generated files to the targets produced by prima-gencls.pl script.