### PR TITLE
Fix a use-after free in destroy_ahead()

### DIFF
--- a/img/codec_bmp.c
+++ b/img/codec_bmp.c
@@ -210,8 +210,8 @@ static Bool
 destroy_ahead(AHEAD *ahead)
 {
 	Bool error = ahead-> error;
-	free(ahead);
 	if (error & ahead-> fi-> wasTruncated) error = false;
+	free(ahead);
 	return error;
 }
 


### PR DESCRIPTION
GCC 13 warns:

In function 'destroy_ahead',
    inlined from 'load' at img/codec_bmp.c:875:10:
img/codec_bmp.c:214:26: warning: pointer 'ahead_1042' used after 'free' [-Wuse-after-free]
  214 |         if (error & ahead-> fi-> wasTruncated) error = false;
      |                     ~~~~~^~~~~
img/codec_bmp.c:213:9: note: call to 'free' here
  213 |         free(ahead);
      |         ^~~~~~~~~~~

This patch fixes it by swapping the two lines.