### PR TITLE
Harmonize Prima Bool type with X11 Bool macro

### DIFF
--- a/include/apricot.h
+++ b/include/apricot.h
@@ -298,7 +298,7 @@ strlcpy(char * dst, const char * src, size_t dstsize);
 extern void *
 prima_mallocz( size_t sz);
 
-typedef I32 Bool;
+typedef int Bool;
 #if PTRSIZE==LONGSIZE
 typedef unsigned long Handle;
 #define PR_HANDLE "lx"


### PR DESCRIPTION
After upgrading GCC to version 14 Prima fails to compile like this on 32-bit x86 platform with perl configured with -Duse64bitint:

  img/codec_Xpm.c: In function ‘apc_img_codec_Xpm’:
  img/codec_Xpm.c:635:28: error: assignment to ‘Bool (*)(struct ImgCodec *, struct _ImgLoadFileInstance *)’ {aka ‘long int (*)(struct ImgCodec *, struct _ImgLoadFileInstance *)’} from incompatible pointer type ‘int (*)(struct ImgCodec *, struct _ImgLoadFileInstance *)’ [-Wincompatible-pointer-types]
    635 |         vmt. load          = load;
        |                            ^
  img/codec_Xpm.c:639:28: error: assignment to ‘Bool (*)(struct ImgCodec *, struct _ImgSaveFileInstance *)’ {aka ‘long int (*)(struct ImgCodec *, struct _ImgSaveFileInstance *)’} from incompatible pointer type ‘int (*)(struct ImgCodec *, struct _ImgSaveFileInstance *)’ [-Wincompatible-pointer-types]
    639 |         vmt. save          = save;
      |                            ^

The cause is that Bool in a type on the left side of the assignment is declared before including <X11/Xpm.h>. At that time Prima defines a Bool as Perl's I32 (which is long int on 32-bit -Duse64bitint; see "include/apricote.h" and Perl <config.h>), but the right side is declared after <X11/Xpm.h> when Bool is a macro expanding to int (see <X11/Xdefs.h>).

This patch changes Prima's Bool to int to match what X11 uses.

CPAN RT#151523