### PR TITLE
Rename pod2pdf to perl-pod2pdf

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -493,7 +493,7 @@ utils/makedoc/makedoc.pl
 utils/makedoc/Makefile
 utils/prima-class.pl
 utils/podview.pl
-utils/pod2pdf.pl
+utils/prima-pod2pdf.pl
 utils/prima-tmlink.pl
 win32/apc.c
 win32/clip.c

--- a/Prima.pm
+++ b/Prima.pm
@@ -534,7 +534,7 @@ L<Prima::IniFile> - support of Windows-like initialization files
 
 L<podview> - POD viewer
 
-L<pod2pdf> - POD printer
+L<prima-pod2pdf> - POD printer
 
 L<Prima::StdBitmap> - shared access to the standard bitmaps
 

--- a/utils/prima-pod2pdf.pl
+++ b/utils/prima-pod2pdf.pl
@@ -19,7 +19,7 @@ sub usage
 
 $0 - convert pod file to a pdf document
 
-format: pod2pdf [options] input.pod [output.pdf|-]
+format: prima-pod2pdf [options] input.pod [output.pdf|-]
 
 options:
 	--help|-h
@@ -99,11 +99,11 @@ if ( $ok ) {
 
 =head1 NAME
 
-pod2pdf - convert pod file to a pdf document
+prima-pod2pdf - convert pod file to a pdf document
 
 =head1 SYNOPSIS
 
-format: pod2pdf [options] input.pod [output.pdf|-]
+format: prima-pod2pdf [options] input.pod [output.pdf|-]
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
pod2pdf name is already used by JONALLEN/pod2pdf-0.42.tar.gz CPAN distribution. This patch adds a prima- prefix as it is already used in utils/prima-tmlink.pl.

CPAN RT#151521