### PR TITLE
Silent warnings about unused variable in type checks

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -836,6 +836,7 @@ int
 main()
 {
 	${ type} foo;
+	(void)foo;
 	return 0;
 }
 EOF


### PR DESCRIPTION
The Makefile.PL checks produce warnigs with -Wall in CFLAGS:

~~~~
Checking for presence of type int8_t...
gcc -D_REENTRANT -D_GNU_SOURCE -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Wno-complain-wrong-lang -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fwrapv -fno-strict-aliasing -I/usr/local/include -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64  -fopenmp -Iinclude -Iinclude/generic -o /tmp/pmts0000  /tmp/pmts0000.c -lpthread -shared -Wl,-z,relro -Wl,--as-needed -Wl,-z,pack-relative-relocs -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld-errors -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 -Wl,--build-id=sha1  -L/usr/local/lib -fstack-protector-strong -fopenmp /tmp/pmts0000.c: In function ‘main’:
/tmp/pmts0000.c:7:16: warning: unused variable ‘foo’ [-Wunused-variable]
    7 |         int8_t foo;
      |                ^~~
yes
~~~~

This patch silents the warnings.