### PR TITLE
Fix WEBP decoding on big-endian platforms

### DIFF
--- a/img/codec_webp.c
+++ b/img/codec_webp.c
@@ -293,7 +293,12 @@ load( PImgCodec instance, PImgLoadFileInstance fi)
 
 	/* read pixels */
 	icon = kind_of( fi-> object, CIcon) && curr->has_alpha;
-	output_buffer->colorspace = fi->blending ? MODE_bgrA : MODE_BGRA;
+	output_buffer->colorspace = fi->blending ?
+#if (BYTEORDER==0x4321) || (BYTEORDER==0x87654321)
+		MODE_Argb : MODE_ARGB;
+#else
+		MODE_bgrA : MODE_BGRA;
+#endif
 	if (( status = WebPDecode(curr->fragment.bytes, curr->fragment.size, config)) != VP8_STATUS_OK) {
 		format_load_error(fi, status);
 		goto EXIT;


### PR DESCRIPTION
t/Image/Loader.t failed for WEBP images on s390x platform:

    #   Failed test 'WEBP/loadAll: image 1 is loaded correctly'
    #   at t/Image/Loader.t line 147.
    #          got: '85'
    #     expected: '1'
    #   Failed test 'WEBP/loadAll: image 2 is loaded correctly'
    #   at t/Image/Loader.t line 147.
    #          got: '86'
    #     expected: '2'
    #   Failed test 'WEBP/map(0,1): image 1 is loaded correctly'
    #   at t/Image/Loader.t line 176.
    #          got: '85'
    #     expected: '1'
    #   Failed test 'WEBP/index: image 1 is loaded correctly'
    #   at t/Image/Loader.t line 155.
    #          got: '85'
    #     expected: '1'
    #   Failed test 'WEBP/inplace: image 1 is loaded correctly'
    #   at t/Image/Loader.t line 162.
    #          got: '85'
    #     expected: '1'
    #   Failed test 'WEBP/map: image 1 is loaded correctly'
    #   at t/Image/Loader.t line 168.
    #          got: '85'
    #     expected: '1'
    #   Failed test 'WEBP/map(1,2): image 1 is loaded correctly'
    #   at t/Image/Loader.t line 175.
    #          got: '85'
    #     expected: '1'
    #   Failed test 'WEBP/map(1,2): image 2 is loaded correctly'
    #   at t/Image/Loader.t line 176.
    #          got: '86'
    #     expected: '2'
    #   Failed test 'WEBP/index: image 2 is loaded correctly'
    #   at t/Image/Loader.t line 155.
    #          got: '86'
    #     expected: '2'
    #   Failed test 'WEBP/inplace: image 2 is loaded correctly'
    #   at t/Image/Loader.t line 162.
    #          got: '86'
    #     expected: '2'
    #   Failed test 'WEBP/map: image 2 is loaded correctly'
    #   at t/Image/Loader.t line 168.
    #          got: '86'
    #     expected: '2'
    #   Failed test 'WEBP/map(2,0): image 2 is loaded correctly'
    #   at t/Image/Loader.t line 175.
    #          got: '86'
    #     expected: '2'
    #   Failed test 'WEBP/loader: image 1 is loaded correctly'
    #   at t/Image/Loader.t line 198.
    #          got: '85'
    #     expected: '1'
    #   Failed test 'WEBP/loader: image 2 is loaded correctly'
    #   at t/Image/Loader.t line 198.
    #          got: '86'
    #     expected: '2'
    # Looks like you failed 14 tests of 313.
    t/Image/Loader.t .......
    Dubious, test returned 14 (wstat 3584, 0xe00)
    Failed 14/313 subtests

When searching for reports about WEBP big-endian bugs I found <https://github.com/DanBloomberg/leptonica/issues/307> referencing to a fix in libwebp
<https://github.com/webmproject/libwebp/commit/3005237a5d68d1e1f465d925040a9507f55e8895>.

This patch uses the same approach and lures libwebp to decode images in the native endianness.

CPAN RT#151593