### PR TITLE
Fix memory handling in prima_fc_fonts()

### DIFF
--- a/unix/fontconfig.c
+++ b/unix/fontconfig.c
@@ -573,6 +573,7 @@ prima_fc_fonts( PFont array, const char *facename, const char * encoding, int *r
 	PFont newarray, f;
 	PHash names = NULL;
 	CharSetInfo * csi = NULL;
+	size_t newsize;
 	int i;
 
 	if ( encoding) {
@@ -598,8 +599,8 @@ prima_fc_fonts( PFont array, const char *facename, const char * encoding, int *r
 	}
 
 	/* make dynamic */
-	i = sizeof(Font) * (*retCount + s-> nfont * ALL_CHARSETS);
-	newarray = array ? realloc(array,i) : malloc(i);
+	newsize = sizeof(Font) * (*retCount + s-> nfont * ALL_CHARSETS);
+	newarray = array ? realloc(array,newsize) : malloc(newsize);
 	if ( !newarray) {
 		FcFontSetDestroy(s);
 		return array;


### PR DESCRIPTION
t/Image/Text.t frequently aborted with "buffer overflow detected" on i686 and s390x platforms:

    #0  0x000003fff79ae3ca in __pthread_kill_implementation () at /lib64/libc.so.6
    #1  0x000003fff7954460 in raise () at /lib64/libc.so.6
    #2  0x000003fff793449c in abort () at /lib64/libc.so.6
    #3  0x000003fff79a0a2a in __libc_message_impl () at /lib64/libc.so.6
    #4  0x000003fff7a3aadc in __fortify_fail () at /lib64/libc.so.6
    #5  0x000003fff7a3a368 in __chk_fail () at /lib64/libc.so.6
    #6  0x000003fff7a3b400 in __memset_chk () at /lib64/libc.so.6
    #7  0x000003fff6ea4cce in bzero
        (__len=<optimized out>, __dest=0x580d3f50ee0, __dest=<optimized out>, __len=<optimized out>)
        at /usr/include/bits/strings_fortified.h:32
    #8  prima_fc_fonts (array=<optimized out>, facename=0x0, encoding=0x0, retCount=0x3ffffff929c)
        at unix/fontconfig.c:610
    #9  0x000003fff6dbd68e in Application_fonts
        (self=2929175997600, name=0x2aa007a31e0 "", encoding=0x2aa005d19b0 "") at class/Application.c:310
    #10 0x000003fff6dd1234 in Image_fonts_FROMPERL (my_perl=<optimized out>, cv=<optimized out>)
        at include/generic/Image.inc:375
    #11 0x000003fff7c4a69a in Perl_pp_entersub () at /lib64/libperl.so.5.38
    #12 0x000003fff7c3a6f2 in Perl_runops_standard () at /lib64/libperl.so.5.38
    #13 0x000003fff7b7b994 in perl_run () at /lib64/libperl.so.5.38
    #14 0x000002aa000013ae in main ()

There were two issues: prima_fc_fonts(..., int *retCount) incorrectly updated its last argument. Next, when called again, it used this wrong argument to compute how much memory will be allocated. However, during this computation an integer could overflow. Then not enough memory could be allocated, and finally bzero() could be asked to zero a memory beyond that allocation.

This patch fixes both issues.

CPAN RT#151594