### PR TITLE
Silent warnings about unsused variables in Makefile.PL probes

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -782,6 +782,7 @@ int
 main()
 {
     void * ixi = $funcname;
+    (void)ixi;
     return 0;
 }
 EOF
@@ -1165,6 +1166,7 @@ int test( void ) { return 1; }
 
 XS(boot_pmts$n1) {
    dXSARGS;
+   (void)items;
    XSRETURN(1);
 }
 D
@@ -1181,6 +1183,7 @@ extern int test ( void );
 
 XS(boot_pmts$n2) {
    dXSARGS;
+   (void)items;
    test();
    XSRETURN(1);
 }
@@ -1851,6 +1854,7 @@ sub setup_libthai
 #include <thai/thwbrk.h>
 int main() {
 	void * ixi = th_brk_wc_find_breaks;
+	(void)ixi;
 	return 0;
 }
 LIBTHAI
@@ -2110,6 +2114,7 @@ int main() {
 	printf("%s\n", GIF_LIB_VERSION);
 	p = MakeMapObject; /* observed some linking failures on the function in v4.1 */
 #endif
+	(void)p;
 	return 0;
 }
 VER


### PR DESCRIPTION
Makefile.PL checks for available functions by assigning their address to a variable. Value of the variable is then never used and GCC warns like this:

    /tmp/pmts0000.c: In function ‘main’:
    /tmp/pmts0000.c:7:12: warning: unused variable ‘ixi’ [-Wunused-variable]
	7 |     void * ixi = strcasecmp;
	  |            ^~~

and like this:

    /usr/lib64/perl5/CORE/XSUB.h:166:20: warning: unused variable ‘items’ [-Wunused-variable]
      166 | #define dITEMS I32 items = (I32)(SP - MARK)
	  |                    ^~~~~
    /usr/lib64/perl5/CORE/XSUB.h:169:23: note: in expansion of macro ‘dITEMS’
      169 |         dSP; dAXMARK; dITEMS
	  |                       ^~~~~~
    /tmp/pmts0000.c:8:4: note: in expansion of macro ‘dXSARGS’
	8 |    dXSARGS;
	  |    ^~~~~~~

This patch silents the warnings.