### PR TITLE
grid: fix sticky=>'n' and sticky=>'s' positioning

### DIFF
--- a/class/Widget/grid.c
+++ b/class/Widget/grid.c
@@ -1064,8 +1064,8 @@ AdjustForSticky(slavePtr, xPtr, yPtr, widthPtr, heightPtr)
 	if (!(sticky&STICK_WEST)) {
 		*xPtr += (sticky&STICK_EAST) ? diffx : diffx/2;
 	}
-	if (!(sticky&STICK_NORTH)) {
-		*yPtr += (sticky&STICK_SOUTH) ? diffy : diffy/2;
+	if (!(sticky&STICK_SOUTH)) {
+		*yPtr += (sticky&STICK_NORTH) ? diffy : diffy/2;
 	}
 }
 


### PR DESCRIPTION
The `sticky` option for `gridConfigure` works opposite to what I expect for `sticky => 'n'` and `sticky => 's'`.
My example code (again derived from your grid example with small changes):
```perl
use 5.020;
use strict;
use warnings;
use Prima qw(Application Label);

my $w = Prima::MainWindow->new(
    backColor => cl::Gray,
);
$w->insert(
	[Label => name => 'north', backColor => cl::Red],
	[Widget => name => 'g', backColor => cl::Green],
	[Label => name => 'south', backColor => cl::Blue],
	[Widget => name => 'y', backColor => cl::Yellow],
);

$w->gridConfigure(north => row => 0, column => 0, sticky => 'n');
$w->gridConfigure(g => row => 0, column => 1,);
$w->gridConfigure(south => row => 1, column => 0, sticky => 's');
$w->gridConfigure(y => row => 1, column => 1);

run Prima;

```
This puts the "north" label at the bottom of its cell, and the "south" label at its top:
![prima_sticky](https://github.com/user-attachments/assets/cfdab42b-f259-4066-970d-9f55d1fecfa2)

The patch swaps the north and south alignments, now it looks how I would expect it:
![prima_sticky_patched](https://github.com/user-attachments/assets/39b3c7ea-a4d1-498e-8bb3-ecd2b89b95e7)

