### PR TITLE
unix/gtk.c: Make Prima's child process robust against signals

### DIFF
--- a/unix/gtk.c
+++ b/unix/gtk.c
@@ -317,6 +317,7 @@ prima_gtk_init(void)
 	if ( socketpair(AF_UNIX, SOCK_STREAM, PF_UNSPEC, gtk_screenshot_sockets) == 0) {
 		gtk_screenshot_pid  = fork();
 		if ( gtk_screenshot_pid == 0 ) {
+			(void) setsid();
 			close(gtk_screenshot_sockets[0]);
 			run_screenshot_app();
 			exit(0);


### PR DESCRIPTION
Signals sent to the application propagate to the whole process group.  If a Prima application handles / ignores a signal, the same signal can kill the child, which (correctly) discards any signal handlers set by the application.

The patch puts the child in its own process group so that it does no longer receive signals sent to the parent process.

This came up in a discussion on PDL: https://github.com/PDLPorters/pdl/pull/492