### PR TITLE
class/Widget/geometry.c: Allow reconfiguring grid cells

### DIFF
--- a/class/Widget/geometry.c
+++ b/class/Widget/geometry.c
@@ -198,9 +198,6 @@ Widget_check_in( Handle self, Handle in, int geometry)
 		h = PWidget( h)-> geomInfo. next;
 	}
 
-	if ( Widget_is_grid_slave(in, self))
-		croak("%s: invalid 'in': already in a grid", method);
-
 	if ( geometry == gtGrid && PWidget(in)->packSlaves)
 		croak("%s: cannot grid into a pack master", method);
 	if ( geometry == gtPack && Widget_has_grid_slaves(in))


### PR DESCRIPTION
I just added a comment to commit 81d941c1bd0d56fc8b9cf48d5751947fbfe68afd.  This commit fixes the segfault for "mixed" widget configuration, but also prohibits calling `grid_configure` twice for the same cell.  The docs say:

> If any of the slaves are already managed by the geometry manager then any unspecified options for them retain their previous values rather than receiving default values.

I was actually using that capability:  In my application I configure the grid rows from top to bottom.  In each row, the cells immediately get their `col` assigned.  Only after the last row is defined, I assign the `row` attribute from top to bottom.  The Prima grid rows are numbered from bottom to top, so I need to know the number of rows before assigning the `row` value for the topmost row.

If there is a technical reason for the extra check, please reject the PR.   The sentence in the documentation should be removed, and I'll reorder my code so that I can set row and column in one go.
