### PR TITLE
Add more `XCHECKPOINT`

### DIFF
--- a/unix/corefont.c
+++ b/unix/corefont.c
@@ -911,6 +911,7 @@ AGAIN:
 	s = hash_fetch( xfontCache, name, strlen( name));
 
 	if ( !s) {
+		XCHECKPOINT;
 		s = XLoadQueryFont( DISP, name);
 		XCHECKPOINT;
 		if ( !s) {
@@ -1087,6 +1088,7 @@ AGAIN:
 		}
 		of-> flags. sloppy = false;
 	}
+	XCHECKPOINT;
 
 	if ( !kf )
 		return true;
@@ -1294,6 +1296,7 @@ AGAIN:
 		}
 	}
 
+	XCHECKPOINT;
 	if (!detail_font_info( info + index, match, kf, by_size)) {
 		Fdebug("font: bad match, try again");
 		goto AGAIN;

--- a/unix/font.c
+++ b/unix/font.c
@@ -502,6 +502,7 @@ match_font( PFontKey fk, PFont font, Matrix matrix)
 	default:
 		return NULL;
 	}
+	XCHECKPOINT;
 
 	if ( !cf2 ) {
 		free(cf);


### PR DESCRIPTION
They show that MacOS font errors from `XLoadQueryFont` on line 915 are from https://github.com/XQuartz/XQuartz/issues/216